### PR TITLE
Ensure notifier is not disposed before setValue

### DIFF
--- a/lib/cached_video_player_plus.dart
+++ b/lib/cached_video_player_plus.dart
@@ -680,6 +680,9 @@ class CachedVideoPlayerPlusController
   Future<void> play() async {
     if (value.position == value.duration) {
       await seekTo(Duration.zero);
+      if (_isDisposed) {
+        return;
+      }
     }
     value = value.copyWith(isPlaying: true);
     await _applyPlayPause();
@@ -721,7 +724,7 @@ class CachedVideoPlayerPlusController
             return;
           }
           final Duration? newPosition = await position;
-          if (newPosition == null) {
+          if (newPosition == null || _isDisposed) {
             return;
           }
           _updatePosition(newPosition);
@@ -786,6 +789,9 @@ class CachedVideoPlayerPlusController
       position = Duration.zero;
     }
     await _videoPlayerPlatform.seekTo(_textureId, position);
+    if (_isDisposed) {
+      return;
+    }
     _updatePosition(position);
   }
 
@@ -890,6 +896,9 @@ class CachedVideoPlayerPlusController
     Future<ClosedCaptionFile>? closedCaptionFile,
   ) async {
     _closedCaptionFile = await closedCaptionFile;
+    if (_isDisposed) {
+      return;
+    }
     value = value.copyWith(caption: _getCaptionAt(value.position));
   }
 


### PR DESCRIPTION
I have a video list and have a restore position function, but sometime when I scroll ListView I get this issue:

```flutter
                       A CachedVideoPlayerPlusController was used after being disposed.
Once you have called dispose() on a CachedVideoPlayerPlusContro...
                       #0      ChangeNotifier.debugAssertNotDisposed.<anonymous closure> (package:flutter/src/foundation/change_notifier.dart:179:9)
                       #1      ChangeNotifier.debugAssertNotDisposed (package:flutter/src/foundation/change_notifier.dart:186:6)
                       #2      ChangeNotifier.notifyListeners (package:flutter/src/foundation/change_notifier.dart:412:27)
                       #3      ValueNotifier.value= (package:flutter/src/foundation/change_notifier.dart:555:5)
                       #4      CachedVideoPlayerPlusController._updatePosition (package:cached_video_player_plus/cached_video_player_plus.dart:862:5)
                       #5      CachedVideoPlayerPlusController.seekTo (package:cached_video_player_plus/cached_video_player_plus.dart:754:5)
                       <asynchronous suspension>
                       #6      _VideoPlayerState._restorePosition (package:*/feed_page.dart:725:7)
                       <asynchronous suspension>
                       #7      _VideoPlayerState.didUpdateWidget.<anonymous closure> (package:*/feed_page.dart:695:35)
                       <asynchronous suspension>
```