### PR TITLE
v4.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,43 @@
+## 4.0.0
+
+_We Marie Kondo'd the entire API! Everything that didn't spark joy got yeeted into the digital void! ✨🗑️_
+
+**BREAKING CHANGES**
+
+- Complete API restructure: `CachedVideoPlayerPlusController` replaced with class-based `CachedVideoPlayerPlus` approach
+- Widget usage changed: Use `VideoPlayer(player.controller)` instead of `CachedVideoPlayerPlus(controller)`
+- Controller access: Video control methods now accessed through `.controller` property (e.g., `player.controller.play()`)
+- Storage migration: Switched from `get_storage` to `shared_preferences` for cache metadata storage
+- Method renames: `removeCurrentFileFromCache()` → `removeFromCache()`
+- Parameter type changes: `removeFileFromCache()` now takes `Uri` instead of `String`
+- Cache key prefix changed internally (handled automatically by migration utility)
+- Default cache duration increased from 30 days to 69 days _(Nice! 😎)_
+- Removed deprecated `CachedVideoPlayerPlusController.network()` constructor
+- Removed classes: `CachedVideoPlayerPlusValue`, `CachedVideoPlayerPlus` widget, `ClosedCaptionFile` implementations
+
+**Features**
+
+- feat: Pre-cache videos without creating player instances using `CachedVideoPlayerPlus.preCacheVideo()`
+- feat: Custom cache key support via `cacheKey` parameter for cleaner cache management _(because sometimes URLs are longer than a CVS receipt)_
+- feat: Custom cache manager support via `cacheManager` parameter
+- feat: Separate download headers via `downloadHeaders` parameter for authentication purposes
+- feat: Cache removal by custom cache key using `removeFileFromCacheByKey()`
+- feat: Automatic migration utility to preserve existing cached video data from v3.x.x
+- feat: Convenience property `player.isInitialized` for easier state checking
+
+**Fixes**
+
+- fix: Web platform cannot play cached videos - improved web compatibility
+- fix: Race condition in cache file removal by making it awaitable _(no more cache file musical chairs!)_
+- fix: StateError exception handling for uninitialized controller access
+
+**Chores**
+
+- chore: Updated dependencies to latest versions with Flutter 3.32 support
+- chore: Restructured from plugin to package architecture
+- chore: Enhanced documentation with migration guide and comprehensive examples _(now with 42% more humor!)_
+- chore: Updated example app to showcase full v4.0.0 feature set
+
 ## 3.0.3
 
 - refactor: lowered sdk constraints to support dart 3.0.0 and above

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -23,7 +23,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "3.0.3"
+    version: "4.0.0"
   characters:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: cached_video_player_plus
 description: "The video_player plugin that went to therapy, worked on its commitment issues, and now actually remembers your videos!"
-version: 3.0.3
+version: 4.0.0
 homepage: https://outdatedguy.rocks
 repository: https://github.com/OutdatedGuy/cached_video_player_plus
 topics:


### PR DESCRIPTION
## What's Changed
* refactor: update git and pub ignore list by @OutdatedGuy in https://github.com/OutdatedGuy/cached_video_player_plus/pull/63
* chore: updated dependencies to latest with Flutter 3.32 by @OutdatedGuy in https://github.com/OutdatedGuy/cached_video_player_plus/pull/64
* refactor!: restructured api to use video_player controller by @OutdatedGuy in https://github.com/OutdatedGuy/cached_video_player_plus/pull/65
* refactor: updated structure from a plugin to a package by @OutdatedGuy in https://github.com/OutdatedGuy/cached_video_player_plus/pull/66
* feat: ability to provide custom cache key identifier by @OutdatedGuy in https://github.com/OutdatedGuy/cached_video_player_plus/pull/67
* feat: ability to provide custom cache manager by @OutdatedGuy in https://github.com/OutdatedGuy/cached_video_player_plus/pull/68
* feat: custom download header for just auth purposes by @OutdatedGuy in https://github.com/OutdatedGuy/cached_video_player_plus/pull/69
* refactor!: use shared_prefs instead of get_storage by @OutdatedGuy in https://github.com/OutdatedGuy/cached_video_player_plus/pull/70
* feat: ability to pre-cache video without creating any instances by @OutdatedGuy in https://github.com/OutdatedGuy/cached_video_player_plus/pull/71
* refactor: change exception to StateError for controller by @OutdatedGuy in https://github.com/OutdatedGuy/cached_video_player_plus/pull/72
* docs: add wit and wisdom to v4.0.0 migration by @OutdatedGuy in https://github.com/OutdatedGuy/cached_video_player_plus/pull/73
* fix(web): cannot play cached videos on web by @OutdatedGuy in https://github.com/OutdatedGuy/cached_video_player_plus/pull/74
* feat: implement cache key generation for video caching by @OutdatedGuy in https://github.com/OutdatedGuy/cached_video_player_plus/pull/75
* docs: fine-tuning documentation by @OutdatedGuy in https://github.com/OutdatedGuy/cached_video_player_plus/pull/76
* docs: update example app to showcase full feature set by @OutdatedGuy in https://github.com/OutdatedGuy/cached_video_player_plus/pull/77
* refactor: await cache file removal to avoid possible race condition by @OutdatedGuy in https://github.com/OutdatedGuy/cached_video_player_plus/pull/78
* docs: updated docs for v4 by @OutdatedGuy in https://github.com/OutdatedGuy/cached_video_player_plus/pull/79
* feat: created bug and feature request templates by @OutdatedGuy in https://github.com/OutdatedGuy/cached_video_player_plus/pull/80


**Full Changelog**: https://github.com/OutdatedGuy/cached_video_player_plus/compare/v3.0.3...v4.0.0