### PR TITLE
changed dataSource of  CachedVideoPlayerPlus.file from Uri.toString()…

### DIFF
--- a/lib/src/cached_video_player_plus.dart
+++ b/lib/src/cached_video_player_plus.dart
@@ -118,7 +118,7 @@ class CachedVideoPlayerPlus {
     this.videoPlayerOptions,
     this.httpHeaders = const <String, String>{},
     this.viewType = VideoViewType.textureView,
-  })  : dataSource = Uri.file(file.absolute.path).toString(),
+  })  : dataSource = file.absolute.path,
         dataSourceType = DataSourceType.file,
         package = null,
         formatHint = null,


### PR DESCRIPTION
I found out that issue with playing local files may be related to wrong path provided to 

```
VideoPlayerController.file(
          File(realDataSource),
          closedCaptionFile: closedCaptionFile,
          videoPlayerOptions: videoPlayerOptions,
          httpHeaders: httpHeaders,
          viewType: viewType,
        ),
```

Value passed here was actually URI string, which includes the file:// scheme — so it ends up being:

/file:/data/user/0/...  

But File constructor expects a file system path, like:

/data/user/0/your.app/cache/....mp4

So changing the way dataSource is created for CachedVideoPlayerPlus.file constructor seems to fix the issue.